### PR TITLE
Add flatpak settings.json location

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Said directories are found below:
 * Mac:
   * `~/Library/Application Support/discord<channel>/`
 * Linux:
-  * `~/.config/discord<channel>/`
+  * Package Manager/tar.gz Installation: `~/.config/discord<channel>/`
+  * Flatpak: `~/.var/app/com.discordapp.Discord/config/discord<channel>/settings.json`
 
 Set `UPDATE_ENDPOINT` and `NEW_UPDATE_ENDPOINT` in `settings.json` as follows:
 


### PR DESCRIPTION
Not entirely sure that `discord<channel>` in the Flatpak is correct, but I would assume that it correlates to ~/.config ala the normal Linux path, so I'm assuming it is.