### PR TITLE
Update apiV1 to fix depreciations

### DIFF
--- a/src/apiV1/index.js
+++ b/src/apiV1/index.js
@@ -1,4 +1,4 @@
-import { existsSync, rmdirSync, mkdirSync } from 'fs';
+import { existsSync, rmSync, mkdirSync } from 'fs';
 
 global.discordBase = global.config.apiBases?.v1 || 'https://discord.com/api';
 
@@ -19,7 +19,7 @@ global.requestCounts = {
 
 const initCache = () => {
   if (existsSync(`../cache`)) {
-    rmdirSync(`../cache`, { recursive: true });
+    rmSync(`../cache`, { recursive: true });
     //return;
   }
 


### PR DESCRIPTION
Update apiV1 to fix the depreciation of rmdirSync.

```
[DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
```